### PR TITLE
RFC: return of Context?

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -49,34 +49,76 @@ Every Span has zero or more **Logs**, each of which being a timestamped event na
 
 Every Span may also have zero or more key/value **Tags**, which do not have timestamps and simply annotate the spans.
 
-Spans may be **propagated**; that is, they may cross process boundaries along with sufficient information to continue the Trace on the far side of the propagation.
+A **TraceContext** is the current state of the distributed request, propagated both within processes and across the boundaries between them.  The TraceContext contains the IDs that tie the spans of a Trace together.  It also can contain user-defined **Trace Attributes**, which are user-defined key/value pairs propagated in-band with the rest of the TraceContext.
 
-**Trace Attributes** are key/value pairs stored in a Span and propagated _in-band_ to all future child Spans. Given a full-stack OpenTracing integration, Trace Attributes enable powerful functionality by transparently propagating arbitrary application data: for example, an end-user id may be added as a Trace Attribute in a mobile app, propagate (via the distributed tracing machinery) into the depths of a storage system, and recovered at the bottom of the stack to identify a particularly expensive SQL query.
+
+**Trace Attributes** are key/value pairs stored in a TraceContext and propagated _in-band_. Given a full-stack OpenTracing integration, Trace Attributes enable powerful functionality by transparently propagating arbitrary application data: for example, an end-user id may be added as a Trace Attribute in a mobile app, propagate (via the distributed tracing machinery) into the depths of a storage system, and recovered at the bottom of the stack to identify a particularly expensive SQL query.
 
 Trace Attributes come with powerful _costs_ as well; since the attributes are propagated in-band, if they are too large or too numerous they may reduce system throughput or contribute to RPC latency.
-
 **Trace Attributes** vs. **Span Tags**
 
-* Trace Attributes are propagated in-band (i.e., alongside the actual application data) across process boundaries. Span Tags are not propagated since they are not inherited from parent Span to child Span.
-* Span Tags are recorded out-of-band from the application data, presumably in the tracing system's storage. Trace Attributes are not necessarily recorded here, though an implementation may elect to.
+* Structure: Trace Attributes exist in the propagated TraceContext; Span Tags live within an individual Span.
+* Propagation: Trace Attributes are propagated in-band (i.e., alongside the actual application data) across process boundaries with the TraceContext. Span Tags are not propagated since they are not inherited from parent Span to child Span.
+* Reporting: Spans are reported out-of-band from application data, so their tags are recorded out-of-band as well.  They should be used to label data for post-hoc analysis in the tracer. Trace Attributes are not necessarily recorded in reports to the tracing backend, though an implementation may elect to.
 
-Also, trace attribute keys have a restricted format: implementations may wish to use them as HTTP header keys (or key suffixes), and of course HTTP headers are case insensitive. As such, trace attribute keys MUST match the regular expression `(?i:[a-z0-9][-a-z0-9]*)`, and – per the `?i:` – they are case-insensitive. That is, the trace attribute key must start with a letter or number, and the remaining characters must be letters, numbers, or hyphens.
+Also, Trace Attribute keys have a restricted format: implementations may wish to use them as HTTP header keys (or key suffixes), and of course HTTP headers are case insensitive. As such, Trace Attribute keys MUST match the regular expression `(?i:[a-z0-9][-a-z0-9]*)`, and – per the `?i:` – they are case-insensitive. That is, the trace attribute key must start with a letter or number, and the remaining characters must be letters, numbers, or hyphens.
 
 
 ## Platform-Independent API Semantics
 
 OpenTracing supports a number of different platforms, and of course the per-platform APIs try to blend in to their surroundings and do as the Romans do. That said, each platform API must model a common set of semantics for the core tracing concepts described above. In this document we attempt to describe those concepts and semantics in a language- and platform-agnostic fashion.
 
+
+### Tracer
+
+The `Tracer` interface must have the following capabilities:
+
+- Start a `Span` that has no parent, commonly referred to as a *root* `Span`, and provide new associated `TraceContext` **(py: `start_trace`, go: `StartTrace`)**
+- Create and start a new child `Span` with a given operation name, based on provided `TraceContext`, updating the context appropriately **(py: `create_span`, go: `CreateSpan`)**
+
 ### Span
 
 The `Span` interface must have the following capabilities:
 
-- Create and start a new child `Span` with a given operation name. Any trace attributes must be passed through into the child. **(py: `start_child`, go: `StartChild`)**
 - Finish the (already-started) `Span`.  Finish should be the last call made to any span instance, and to do otherwise leads to undefined behavior. **(py: `finish`, go: `Finish`)**
 - Set a key:value tag on the `Span`. The key must be a `string`, and the value must be either a `string`, a `boolean`, or a numeric type. Behavior for other value types is undefined. If multiple values are set to the same key (i.e., in multiple calls), implementation behavior is also undefined. **(py: `set_tag`, go: `SetTag`)**
 - Add a new log event to the `Span`, accepting an event name `string` and an optional structured payload argument. If specified, the payload argument may be of any type and arbitrary size, though implementations are not required to retain all payload arguments (or even all parts of all payload arguments). **(py: `log_event, log_event_with_payload`, go: `LogEvent, LogEventWithPayload`)**
-- Set a trace attribute, which is a simple string:string pair. Note that newly-set trace attributes are only guaranteed to propagate to *future* children of the given `Span`. See the diagram below. **(py: `set_trace_attribute`, go: `SetTraceAttribute`)**
-- Get a trace attribute by key. **(py: `get_trace_attribute`, go: `TraceAttribute`)**
+
+
+### TraceContext
+
+A TraceContext is responsible for:
+
+a. providing a key/value data store that will be used by the tracer and end-user, 
+b. encoding TraceContext instances in a manner suitable for propagation, and
+c. for taking that encoded data and using it to generate TraceContext instances that are used to continue an overarching Trace.
+
+Typically the propagation will take place across an RPC boundary, but message queues and other IPC mechanisms are also reasonable places pass TraceContext.
+
+The encoded form of a propagated span is tracer implementation-specific, but should be divided into two components:
+
+1. The core identifying information for the current Span, referred to as the "context snapshot" (for example, in Dapper this would include a `trace_id`, a `span_id`, and a bitmask representing the sampling status for the given trace)
+1. Any Trace Attributes
+
+The encoded data is separated in this way for a variety of reasons; the most important is to give OpenTracing users a portable way to opt out of Trace Attribute propagation entirely if they deem it a stability risk.
+
+The propagation and trace-joining methods come in two flavors: binary and text.
+
+- The *text* format is a platform-idiomatic map from (unicode) `string` to `string`; it is better-suited to pretty-printing and debugging
+- The *binary* format is an opaque byte array and is better-suited to compact, high-performance encoding, decoding, and transmission
+
+Note that there is no expectation that different tracing systems propagate `TraceContext` in compatible ways. Though OpenTracing is agnostic about the tracing implementation, for successful inter-process handoff it's essential that the processes on both sides of a propagation use the same tracing implementation.
+
+The `TraceContext` interface must have the following capabilities:
+- Propagating a TraceContext instance by encoding it as either...
+  - a binary value, or
+  - a unicode `string->string` map, where the keys are suitable for use in HTTP headers (see the notes about "trace attribute" keys above)
+- Returning a new TraceContext instance that recreates stored/propagated TraceContext via either...
+  - a binary value
+  - a unicode `string->string` map
+- A utility method which retrieves the previous span (eg. `get_current_span`)
+- Read a Trace Attribute (`get_trace_attribute`)
+- Set a Trace Attribute, which is a simple string:string pair. Note that newly-set trace attributes are only guaranteed to propagate to *future* children of the given `Span`. See the diagram below. **(py: `set_trace_attribute`, go: `SetTraceAttribute`)**
 
 ```
         [Span A]
@@ -93,38 +135,3 @@ The `Span` interface must have the following capabilities:
                 |        |        |     AS SPANS G, H, AND I.
             [Span G] [Span H] [Span I]
 ```
-
-
-### Tracer
-
-The `Tracer` interface must have the following capabilities:
-
-- Start a `Span` that has no parent, commonly referred to as a *root* `Span` **(py: `start_trace`, go: `StartTrace`)**
-- Provide some form of access to a SpanPropagator (whether that's through embedding, inheritance, containment, or something else is per-platform)
-
-### SpanPropagator
-
-A SpanPropagator is responsible (a) for encoding Span instances in a manner suitable for propagation, and (b) for taking that encoded data and using it
-to generate Span instances that are placed appropriately in the overarching Trace. Typically the propagation will take place across an RPC boundary, but message queues and other IPC mechanisms are also reasonable places to use a SpanPropagator.
-
-The encoded form of a propagated span is divided into two components:
-
-1. The core identifying information for the Span, referred to as the "context snapshot" (for example, in Dapper this would include a `trace_id`, a `span_id`, and a bitmask representing the sampling status for the given trace)
-1. Any trace attributes (per Span's ability to set trace attributes that propagate across process boundaries)
-
-The encoded data is separated in this way for a variety of reasons; the most important is to give OpenTracing users a portable way to opt out of Trace Attribute propagation entirely if they deem it a stability risk.
-
-The propagation and trace-joining methods come in two flavors: binary and text.
-
-- The *text* format is a platform-idiomatic map from (unicode) `string` to `string`; it is better-suited to pretty-printing and debugging
-- The *binary* format is an opaque byte array and is better-suited to compact, high-performance encoding, decoding, and transmission
-
-Note that there is no expectation that different tracing systems propagate `Spans` in compatible ways. Though OpenTracing is agnostic about the tracing implementation, for successful inter-process handoff it's essential that the processes on both sides of a propagation use the same tracing implementation.
-
-The `SpanPropagator` interface must have the following capabilities:
-- Propagating a Span instance by encoding it as either...
-  - a pair of binary values **(py: `propagate_span_as_binary`, go: `PropagateSpanAsBinary`)**, or
-  - a pair of unicode `string->string` maps, where the keys are suitable for use in HTTP headers (see the notes about "trace attribute" keys above) **(py: `propagate_span_as_text`, go: `PropagateSpanAsText`)**
-- Returning a new Span instance that joins to a Span previously propagated via either...
-  - a pair of binary values **(py: `join_trace_from_binary`, go: `JoinTraceFromBinary`)**, or
-  - a pair of unicode `string->string` maps **(py: `join_trace_from_text`, go: `JoinTraceFromText`)**

--- a/use-cases.md
+++ b/use-cases.md
@@ -10,19 +10,18 @@ This page aims to illustrate common use cases that developers who instrument the
 
 ```python
     def top_level_function():
-        span1 = tracer.start_trace('top_level_function')
+        ctx, span1 = tracer.start_trace('top_level_function')
         try:
             . . . # business logic
         finally:
             span1.finish()
 ```
 
-As a follow-up, suppose that as part of the business logic above we call another `function2` that we also want to trace. In order to attach that function to the ongoing trace, we need a way to access `span1`. We discuss how it can be done later, for now let's assume we have a helper function `get_current_span` for that:
+As a follow-up, suppose that as part of the business logic above we call another `function2` that we want to report on in our trace. In order to attach a Span reporting this function to the ongoing trace, we need to provide the Context that carries the trace state.. We discuss how it can be done later, for now let's assume we have a helper function `get_current_context` for that:
 
 ```python
     def function2():
-        span2 = get_current_span().start_child('function2') \
-            if get_current_span() else None
+        span2 = tracer.create_span(get_current_context(), 'function2')
         try:
             . . . # business logic
         finally:
@@ -30,7 +29,7 @@ As a follow-up, suppose that as part of the business logic above we call another
                 span2.finish()
 ```
 
-We assume that, for whatever reason, the developer does not want to start a new trace in this function if one hasn't been started by the caller already, so we account for `get_current_span` potentially returning `None`.
+We assume that, for whatever reason, the developer does not want to start a new trace in this function if one hasn't been started by the caller already.  This is accounted for by using `create_span`, which can deal with `get_current_context` potentially returning `None`.
 
 These two examples are intentionally naive. Usually developers will not want to pollute their business functions directly with tracing code, but use other means like a [function decorator in Python](https://github.com/uber-common/opentracing-python-instrumentation/blob/master/opentracing_instrumentation/local_span.py#L59):
 
@@ -44,8 +43,8 @@ These two examples are intentionally naive. Usually developers will not want to 
 
 When a server wants to trace execution of a request, it generally needs to go through these steps:
 
-  1. Attempt to join an existing trace given a Span that's been propagated alongside the incoming request (in case the trace has already been started by the client), or create a new trace if no such propagated Span could be found.
-  1. Store the newly created Span in some _request context_ that is propagated throughout the application, either by application code, or by the RPC framework.
+  1. Create a new Span, either attached to an upstream trace by a Context that's been propagated alongside the incoming request (in case the trace has already been started by the client), or a new trace Context if no such propagated Context could be found.
+  1. Store the newly created Context in a way that can be propagated throughout the application, either by application code, or by the RPC framework.  (eg. thread-local storage, manual propagation)
   1. Finally, close the Span using `span.finish()` when the server has finished processing the request.
 
 #### Joining to a Trace from an Incoming Request
@@ -53,29 +52,21 @@ When a server wants to trace execution of a request, it generally needs to go th
 Let's assume that we have an HTTP server, and the Span is propagated from the client via HTTP headers, accessible via `request.headers`:
 
 ```python
-    span = tracer.join_trace_from_text(
-        operation_name=operation,
-        context_snapshot=request.headers,
-        trace_attributes=request.headers
-    )
+    ctx = context.from_string(request.headers)
+    span = tracer.join_trace(operation_name=operation, context=ctx)
 ```
 
-Here we set both arguments of the decoding method to the `headers` map. The Tracer object knows which headers it needs to read in order to reconstruct the context snapshot and any Trace Attributes.
+Assuming the same Tracer implementation is used upstream in the client, the Tracer object knows which Context fields it needs to read in order to reconstruct the trace.
 
 The `operation` above refers to the name the server wants to give to the Span. For example, if the HTTP request was a POST against `/save_user/123`, the operation name can be set to `post:/save_user/`. OpenTracing API does not dictate how applications name the spans.
 
 #### Joining to or Starting a Trace from an Incoming Request
 
-The `span` object above can be `None` if the Tracer did not find relevant headers in the incoming request: presumably because the client did not send them. In this case the server needs to start a brand new trace.
+The `span` object above can be `None` if the Tracer did not find relevant headers in the incoming request: presumably because the client did not send them. In this case the server needs to start a brand new trace.  To do this, use `start_trace` instead: in the presence of a Context, a trace is continued, and in the absence of one, a new Context and root Span are both created.
 
 ```python
-    span = tracer.join_trace_from_text(
-        operation_name=operation,
-        context_snapshot=request.headers,
-        trace_attributes=request.headers
-    )
-    if span is None:
-        span = tracer.start_trace(operation_name=operation)
+    ctx = context.from_string(request.headers)
+    span = tracer.start_trace(operation_name=operation, context=ctx)
     span.set_tag('http.method', request.method)
     span.set_tag('http.url', request.full_url)
 ```
@@ -84,9 +75,9 @@ The `set_tag` calls are examples of recording additional information in the Span
 
 #### In-Process Request Context Propagation
 
-Request context propagation refers to application's ability to associate a certain _context_ with the incoming request such that this context is accessible in all other layers of the application within the same process. It can be used to provide application layers with access to request-specific values such as the identity of the end user, authorization tokens, and the request's deadline. It can also be used for transporting the current tracing Span.
+Request context propagation refers to application's ability to associate a certain Context with each request such that this context is accessible in all other layers of the application within the same process. The primary role of Context for tracing is transporting the current trace state as required by the tracer: for instance, the global ID of a request trace and the ID of the last (parent) Span.  However, with Trace Attributes it can be used to provide application layers with access to request-specific values such as the identity of the end user, authorization tokens, and the request's deadline.
 
-Implementation of request context propagation is outside the scope of the OpenTracing API, but it is worth mentioning them here to better understand the following sections. There are two commonly used techniques of context propagation:
+Implementation of in-process Context propagation is currently outside the scope of the OpenTracing API, but it is worth mentioning them here to better understand the following sections. There are two commonly used techniques of context propagation:
 
 ##### Implicit Propagation
 
@@ -120,35 +111,27 @@ In explicit propagation techniques the application code is structured to pass ar
 
 The downside of explicit context propagation is that it leaks what could be considered an infrastructure concern into the application code. This [Go blog post](https://blog.golang.org/context) provides an in-depth overview and justification of this approach.
 
-### Tracing Client Calls
+### Tracing Client Calls and Distributed Context Propgataion
 
-When an application acts as an RPC client, it is expected to start a new tracing Span before making an outgoing request, and propagate the new Span along with that request. The following example shows how it can be done for an HTTP request. 
+When an application acts as an RPC client, it is expected to start a new tracing Span before making an outgoing request, which will represent the client timings of the request.  Additionally, RPC instrumentation is tasked with propagating the Context along with that request. The following example shows how it can be done for an HTTP request. 
 
 ```python
     def traced_request(request, operation, http_client):
         # retrieve current span from propagated request context
-        parent_span = get_current_span()
-
-        # start a new child span or a brand new trace if no parent
-        if parent_span is None:
-            span = tracer.start_trace(operation_name=operation)
-        else:
-            span = parent_span.start_child(operation_name=operation)
+        ctx = get_current_context()
+        span = tracer.create_span(operation_name=operation, context=ctx)
         span.set_tag('http.url', request.full_url)
 
-        # Propagate the Span via HTTP request headers
-        h_ctx, h_attr = tracer.propagate_span_as_text(span)
+        # Propagate the Context via HTTP request headers
+        header_ctx = ctx.to_string()
 
-        for key, value in h_ctx.iteritems():
+        for key, value in header_ctx.iteritems():
             request.add_header(key, value)
-        if h_attr:
-            for key, value in h_attr.iteritems():
-                request.add_header(key, value)
 
         # define a callback where we can finish the span 
         def on_done(future):
             if future.exception():
-                span.log_event_with_payload('exception', exception)
+                span.log('exception', payload=exception)
             else:
                 span.set_tag('http.status_code', future.result().status_code)
             span.finish()
@@ -163,37 +146,42 @@ When an application acts as an RPC client, it is expected to start a new tracing
             raise
 ```
 
-  * The `get_current_span()` function is not a part of the OpenTracing API. It is meant to represent some util method of retrieving the current Span from the current request context propagated implicitly (as is often the case in Python).
-  * The encoding function `propagate_span_as_text` returns two maps, one representing a snapshot of the Span's context, and the other the Trace Attributes. We copy both maps into the HTTP request headers.
-  * We assume the HTTP client is asynchronous, so it returns a Future, and we need to add an on-completion callback to be able to finish the current child Span.
-  * If the HTTP client returns a future with exception, we log the exception to the Span with `log_event_with_payload` method.
+Notes on this example:
+  * The `get_current_context()` function is not a part of the OpenTracing API. It is meant to represent some util method of retrieving the current TraceContext, which can be achieved either implicitly or explicitly as discussed above.
+  * We assume the HTTP client is asynchronous, so it returns a Future, and we need to add an on-completion callback to be able to finish the current child Span.  The synchronous case is trivially similar for instrumentation.
+  * If the HTTP client returns a future with exception, we log the exception to the Span with `log` method.
   * Because the HTTP client may throw an exception even before returning a Future, we use a try/catch block to finish the Span in all circumstances, to ensure it is reported and avoid leaking resources.
 
 
-### Using Distributed Context Propagation
+### Using Trace Attributes
 
-The client and server examples above propagated the Span/Trace over the wire, including any Trace Attributes. The client may use the Trace Attributes to pass additional data to the server and any other downstream server it might call.
+The client and server examples above propagated the TraceContext over the wire, including both Tracer-specific state related to the current request as well as user-added Trace Attributes. The client may use the Trace Attributes to pass additional data to the server and any other downstream server it might call.
 
 ```python
 
     # client side
-    span.set_trace_attribute('auth-token', '.....')
+    ctx.set_attribute('auth-token', '.....')
+
+    ...
 
     # server side (one or more levels down from the client)
-    token = span.get_trace_attribute('auth-token')
+    token = ctx.get_attribute('auth-token')
 ```
 
 ### Logging Events
 
-We have already used `log_event_with_payload` in the client Span use case. Events can be logged without a payload, and not just where the Span is being created / finished. For example, the application may record a cache miss event in the middle of execution, as long as it can get access to the current Span from the request context:
+We have already used `log` in the client Span use case. Events can be logged without a payload, and not just where the Span is being created / finished. For example, the application may record a cache miss event in the middle of execution, as long as it can get access to the current Span:
 
 ```python
 
-    span = get_current_span()
-    span.log_event('cache-miss') 
+    # if the Span isn't handy, grab it
+    span = get_current_context().get_current_span()
+
+    # add an event
+    span.log_event('cache-miss')
 ```
 
-The tracer automatically records a timestamp of the event, in contrast with tags that apply to the entire Span. It is also possible to associate an externally provided timestamp with the event, e.g. see [Log (Go)](https://github.com/opentracing/opentracing-go/blob/ca5c92cf/span.go#L53).
+The tracer automatically records a timestamp of the event, in contrast with tags which are labels applying to the entire Span. It is also possible to associate an externally provided timestamp with the event, e.g. see [Log (Go)](https://github.com/opentracing/opentracing-go/blob/ca5c92cf/span.go#L53).
 
 ### Recording Spans With External Timestamps
 


### PR DESCRIPTION
We started off with a TraceContext, then decided to try downplaying the concept of DCP for API simplification.  However, given the collective interest in Trace Attributes voiced during the last hangout, I think this decision is worth revisiting, because wedging Trace Attributes into the Span concept is a bit awkward.

It can be hard to think through all the consequences of such a change.  To explore it, I've gone through the use-cases.md and spec.md docs and rewritten them as if the below proposal were enacted.

As a side-note, it turns out that use-cases.md is kind of the TodoMVC of this project right now, allowing one to do thought experiments on changes.  However, I did discover taht there was one fundamental use-case that seemed missing from it, which is a span with multiple children.  This case would be vulnerable to certain types of Span/Context management changes.  And it ended up breaking my proposal!

After doing an initial "implementation" then a few iterations, I have to consider it a non-starter: it requires propagation of both Context and the current parent Span.  I am not convinced that the Tracer can manage to keep track of what the correct parent span is without user tracking it.

Nonetheless here's the original write-up, before I discovered my error.
### Proposed structure

A tracer implements the following things:
#### Tracer
- Tracer-specific implementations of
  - `TraceContext` class (possibly itself complying with a DCP interface down the road)
  - `Span` class
- Trace initiation, span management methods
  - `TraceContext, Span start_trace()`
  - `Span join_trace(TraceContext)`
  - `Span create_span(TraceContext)`
#### TraceContext
- Propagation
  - `k,v to_string()` (and/or binary)
  - `Context from_string()` (and/or binary)
- Tracce Attribute management
  - `String get_trace_attribute(k)`
    - Private: `get_context_snapshot(**tracer_specific)` -- lets Tracer manage own state separately
  - `set_trace_attribute(k, v)`
    - Private: `set_context_snapshot(**tracer_specific)` -- lets Tracer manage own state separately
- Convenience
  - `Span get_current_span()`
#### Span
- Span management
  - `finish()`
- Span enrichment
  - `set_tag(k, v)`
  - `log(event, payload)`
- Span propagation
  - (this is now handled by TraceContext)
### Reasoning

The distinction between Tags and Trace Attributes seems to be fairly blurry under the current proposal, which adds Trace Attributes to Spans.  This proposal suggests a clarification by returning to a structure that's similar to the originally-proposed interface (reviving `TraceContext`).

In this model, a Span is a unit of data for the tracer to consider reporting, a Trace Attribute is a unit of data to be propagated in-band, and a TraceContext provides the continuity needed to both generate new Spans and read/write Attributes.
#### Advantages vs current state:
- Clear separation of Tags and Attributes
- Instrumenter no longer has to worry about which things are Trace Attributes and which ones are Trace Context -- this is managed for them by tracer
- Possible to implement propagation-only tracers without Span creation (all non-TraceContext methods can be no-ops)
#### Disadvantages vs current state:
- `TraceContext.get_current_span()` method indicates a lack of separation between tracer and DCP interface, but vastly simplifies the task of in-process CP.  If we want cleanly separable DCP, another layer of indirection could have an OT Tracer load an independently-developed DistributedContext that has only r/w/encode/decode methods, and augment it as a TraceContext.  Non-tracing code developed around DistributedContext would interoperate with the Tracer's use of the context.
- Note that above `join_trace`,`create_span` must either mutate the TraceContext (shown) or return an updated copy 
